### PR TITLE
parse address in hat.New() instead of always prepending http to the URL

### DIFF
--- a/hat.go
+++ b/hat.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // T represents a test instance.
@@ -26,12 +28,12 @@ func New(t *testing.T, addr string) *T {
 		Timeout: time.Second * 5,
 	}
 
+	u, err := url.Parse(addr)
+	require.NoError(t, err)
+
 	return &T{
-		T: t,
-		URL: &url.URL{
-			Scheme: "http",
-			Host:   addr,
-		},
+		T:      t,
+		URL:    u,
 		Client: client,
 	}
 }


### PR DESCRIPTION
This causes issues if the httptest client returns a URL already containing `http://`.

If we need to guarantee that `http://` is there we would just add a check after the URL is parsed.