### PR TITLE
preserve the trailing slash if one exists in RunPath()'s elem

### DIFF
--- a/hat.go
+++ b/hat.go
@@ -56,10 +56,8 @@ func (t *T) Run(name string, fn func(t *T)) {
 func (t *T) RunPath(elem string, fn func(t *T)) {
 	t.Run(elem, func(t *T) {
 		t.URL.Path = path.Join(t.URL.Path, elem)
-		if len(elem) > 0 {
-			if elem[len(elem)-1] == '/' && t.URL.Path != "/" {
-				t.URL.Path += "/"
-			}
+		if elem[len(elem)-1] == '/' && t.URL.Path != "/" {
+			t.URL.Path += "/"
 		}
 
 		fn(t)


### PR DESCRIPTION
Since `path.Join` strips the trailing slash from URLs some routes in wapi return 307, redirecting to the same route with a trailing slash.

This preserves the trailing slash if one exists in the elem.

There's probably a more permanent solution to this. Thoughts?