### PR TITLE
Add CombineRequestOptions

### DIFF
--- a/hat.go
+++ b/hat.go
@@ -56,6 +56,7 @@ func (t *T) Run(name string, fn func(t *T)) {
 func (t *T) RunPath(elem string, fn func(t *T)) {
 	t.Run(elem, func(t *T) {
 		t.URL.Path = path.Join(t.URL.Path, elem)
+		// preserve trailing slash
 		if elem[len(elem)-1] == '/' && t.URL.Path != "/" {
 			t.URL.Path += "/"
 		}

--- a/request.go
+++ b/request.go
@@ -26,6 +26,10 @@ func URLParams(v url.Values) RequestOption {
 func Path(elem string) RequestOption {
 	return func(_ testing.TB, req *http.Request) {
 		req.URL.Path = path.Join(req.URL.Path, elem)
+		// preserve trailing slash
+		if elem[len(elem)-1] == '/' && req.URL.Path != "/" {
+			req.URL.Path += "/"
+		}
 	}
 }
 


### PR DESCRIPTION
Does the same thing as `CombineResponseAssertions` but for `RequestOption`s.

Also fixed `Path` to use `path.Join` and to preserve the trailing slash if present