### PR TITLE
Feature/t helper

### DIFF
--- a/hat.go
+++ b/hat.go
@@ -42,6 +42,7 @@ func New(t *testing.T, addr string) *T {
 // The subtest inherits the settings of T.
 func (t *T) Run(name string, fn func(t *T)) {
 	t.T.Run(name, func(tt *testing.T) {
+		tt.Helper()
 		t := *t
 		t.T = tt
 		u := *t.URL

--- a/response.go
+++ b/response.go
@@ -14,6 +14,7 @@ type ResponseAssertion func(t testing.TB, r Response)
 // calls each member of asserts in the provided order.
 func CombineResponseAssertions(as ...ResponseAssertion) ResponseAssertion {
 	return func(t testing.TB, r Response) {
+		t.Helper()
 		for _, a := range as {
 			a(t, r)
 		}
@@ -30,6 +31,7 @@ type Response struct {
 // Assert must be called for every response as it will ensure the body is closed.
 // If you want to continue to reuse the connection, you must read the response body.
 func (r Response) Assert(t testing.TB, assertions ...ResponseAssertion) Response {
+	t.Helper()
 	defer r.Body.Close()
 
 	for _, a := range assertions {


### PR DESCRIPTION
This pr allows `t.Log`s in `RequestOption`s and `ResponseAssertion`s to show the line number of the test they are called from instead of an arbitrary line number from inside hat.

Before
```
request.go:91: PATCH /organizations/7811201446115661389/members/accounts/7811201446215032237 HTTP/1.1
    Host: 127.0.0.1:42629
    User-Agent: Go-http-client/1.1
    Transfer-Encoding: chunked
    Api-Key: mHmXoHKbACnpWshkUVsr
    Accept-Encoding: gzip
    
    21
    {"op":"add","nodes":"roster.add"}
    0
    
request.go:76: PATCH http://127.0.0.1:42629/organizations/7811201446115661389/members/accounts/7811201446215032237
response.go:36: body:
    HTTP/1.1 200 OK
    Content-Length: 107
    Access-Control-Allow-Credentials: true
    Content-Type: application/json
    Date: Thu, 07 Jun 2018 23:19:47 GMT
    Request-Id: 5b19bd93-16fd418a6326acf1199047bd
    Rl-Bucket: long
    Rl-Capacity: 60000
    Rl-Level: 100
    Version: wapi-integration-testing
    
    {"id":7811201446215032237,"id_str":"7811201446215032237","msg":"Account permissions successfully updated."}
```

After
```
organizations_intg_test.go:436: PATCH /organizations/7811087887164865469/members/accounts/7811087887223200829 HTTP/1.1
    Host: 127.0.0.1:43201
    User-Agent: Go-http-client/1.1
    Transfer-Encoding: chunked
    Api-Key: a8fkWwTHbPHtPxDHcVu0
    Accept-Encoding: gzip
    
    21
    {"op":"add","nodes":"roster.add"}
    0
    
organizations_intg_test.go:444: PATCH http://127.0.0.1:43201/organizations/7811087887164865469/members/accounts/7811087887223200829
organizations_intg_test.go:444: body:
    HTTP/1.1 200 OK
    Content-Length: 107
    Access-Control-Allow-Credentials: true
    Content-Type: application/json
    Date: Thu, 07 Jun 2018 21:29:37 GMT
    Request-Id: 5b19a3c1-4cb34acfe89ca89041ec49bd
    Rl-Bucket: long
    Rl-Capacity: 60000
    Rl-Level: 100
    Version: wapi-integration-testing
    
    {"id":7811087887223200829,"id_str":"7811087887223200829","msg":"Account permissions successfully updated."}
```