### PR TITLE
feat: Add persistent opts

### DIFF
--- a/hat.go
+++ b/hat.go
@@ -20,6 +20,8 @@ type T struct {
 
 	URL    *url.URL
 	Client *http.Client
+	// persistentOpts are run on every request
+	persistentOpts []RequestOption
 }
 
 // New creates a *T from a *testing.T.
@@ -36,6 +38,10 @@ func New(t *testing.T, baseURL string) *T {
 		URL:    u,
 		Client: client,
 	}
+}
+
+func (t *T) AddPersistentOpts(opts ...RequestOption) {
+	t.persistentOpts = append(t.persistentOpts, opts...)
 }
 
 // Run creates a subtest.

--- a/request.go
+++ b/request.go
@@ -113,6 +113,9 @@ func (t T) Request(method string, opts ...RequestOption) Request {
 			req, err := http.NewRequest(method, t.URL.String(), nil)
 			require.NoError(t, err, "failed to create request")
 
+			for _, pOpt := range t.persistentOpts {
+				pOpt(t, req)
+			}
 			for _, opt := range opts {
 				opt(t, req)
 			}


### PR DESCRIPTION
Mainly for supporting persistent authentication for a sessioned
hat. Without this, it's more tedious to always add the opt
to all requests as a user of the lib

The alternative was messing with the http client transport, but the comments in the go lib explicitly state not to do that. The transport should not modify requests.